### PR TITLE
switch to using dockerfile plugin for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,17 +162,21 @@ sed -i '' -e 's/kbastani/'$username'/g' \
     ./deployment/docker/docker-compose-build.yml
 ```
 
-_The final command replaces my name in each pom.xml file that is used for building the container images._
-
-```bash
-sed -i '' -e 's/kbastani/'$username'/g' \
-    ./pom.xml
-```
-
 Now you're ready to build the project and your docker containers.
 
+If you have JDK and Maven on your workstation you should be able to simply run:
+
 ```bash
-mvn clean install -DskipTests
+mvn clean install -DskipTests -Ddocker.user=$username
+```
+
+If you do not have JDK and Maven on your workstation you may be able to use a maven Docker image to build your images:
+
+```bash
+docker run -it --rm --name my-maven-project \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$(pwd)":/src -w /src maven:3.6-jdk-11 \
+  mvn clean install -DskipTests -Ddocker.user=$username
 ```
 
 After everything has successfully been built, you are now ready to deploy the containers to your Docker Hub account. Run the following command.

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.1-jre-slim-sid
+MAINTAINER Kenny
+
+CMD ["/usr/bin/java", "-jar", "/usr/share/myservice/myservice.jar"]
+
+# Add Maven dependencies (not shaded into the artifact; Docker-cached)
+#ADD target/lib           /usr/share/myservice/lib
+# Add the service itself
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/myservice/myservice.jar

--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -36,30 +36,25 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <imageName>${docker.user}/${project.name}</imageName>
-                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
-                    <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.jar</include>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.9</version>
+            <executions>
+                <execution>
+                <id>default</id>
+                <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <repository>${docker.user}/${project.name}</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+            </configuration>
             </plugin>
         </plugins>
     </build>

--- a/edge-service/Dockerfile
+++ b/edge-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.1-jre-slim-sid
+MAINTAINER Kenny
+
+CMD ["/usr/bin/java", "-jar", "/usr/share/myservice/myservice.jar"]
+
+# Add Maven dependencies (not shaded into the artifact; Docker-cached)
+#ADD target/lib           /usr/share/myservice/lib
+# Add the service itself
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/myservice/myservice.jar

--- a/edge-service/pom.xml
+++ b/edge-service/pom.xml
@@ -58,30 +58,25 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <imageName>${docker.user}/${project.name}</imageName>
-                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
-                    <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.jar</include>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.9</version>
+            <executions>
+                <execution>
+                <id>default</id>
+                <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <repository>${docker.user}/${project.name}</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+            </configuration>
             </plugin>
         </plugins>
     </build>

--- a/friend-service/Dockerfile
+++ b/friend-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.1-jre-slim-sid
+MAINTAINER Kenny
+
+CMD ["/usr/bin/java", "-jar", "/usr/share/myservice/myservice.jar"]
+
+# Add Maven dependencies (not shaded into the artifact; Docker-cached)
+#ADD target/lib           /usr/share/myservice/lib
+# Add the service itself
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/myservice/myservice.jar

--- a/friend-service/pom.xml
+++ b/friend-service/pom.xml
@@ -125,30 +125,25 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <imageName>${docker.user}/${project.name}</imageName>
-                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
-                    <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.jar</include>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.9</version>
+            <executions>
+                <execution>
+                <id>default</id>
+                <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <repository>${docker.user}/${project.name}</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+            </configuration>
             </plugin>
         </plugins>
     </build>

--- a/recommendation-service/Dockerfile
+++ b/recommendation-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.1-jre-slim-sid
+MAINTAINER Kenny
+
+CMD ["/usr/bin/java", "-jar", "/usr/share/myservice/myservice.jar"]
+
+# Add Maven dependencies (not shaded into the artifact; Docker-cached)
+#ADD target/lib           /usr/share/myservice/lib
+# Add the service itself
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/myservice/myservice.jar

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -92,30 +92,25 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <imageName>${docker.user}/${project.name}</imageName>
-                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
-                    <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.jar</include>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.9</version>
+            <executions>
+                <execution>
+                <id>default</id>
+                <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <repository>${docker.user}/${project.name}</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+            </configuration>
             </plugin>
         </plugins>
     </build>

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11.0.1-jre-slim-sid
+MAINTAINER Kenny
+
+CMD ["/usr/bin/java", "-jar", "/usr/share/myservice/myservice.jar"]
+
+# Add Maven dependencies (not shaded into the artifact; Docker-cached)
+#ADD target/lib           /usr/share/myservice/lib
+# Add the service itself
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/myservice/myservice.jar

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -125,31 +125,27 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <imageName>${docker.user}/${project.name}</imageName>
-                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
-                    <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.jar</include>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.9</version>
+            <executions>
+                <execution>
+                <id>default</id>
+                <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <repository>${docker.user}/${project.name}</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+            </configuration>
             </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
There is some magic in the docker-maven-plugin that obscures what is
actually in the image.  This switches to the dockerfile-maven-plugin
which utilizes a Dockerfile per app to build the resultant image.

This way you can be a lot more obvious about what is inside the image,
and it allows ops/security/etc a way to shape the underlying base image
to contain appropriate compliance items.