### PR TITLE
update microservices to support kubernetes

### DIFF
--- a/edge-service/pom.xml
+++ b/edge-service/pom.xml
@@ -34,6 +34,14 @@
             <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-kubernetes-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-kubernetes-ribbon</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>1.4.11.1</version>

--- a/edge-service/src/main/resources/application.yml
+++ b/edge-service/src/main/resources/application.yml
@@ -2,13 +2,15 @@ spring:
   profiles:
     active: development
   cloud:
+    kubernetes:
+      enabled: false
     gateway:
       discovery:
         locator:
           enabled: false
       routes:
-      - id: FRIEND-SERVICE
-        uri: lb://FRIEND-SERVICE
+      - id: friend-service
+        uri: lb://friend-service
         predicates:
         - name: Path
           args:
@@ -18,8 +20,8 @@ spring:
           args:
             regexp: "/friend/(?<remaining>.*)"
             replacement: "/${remaining}"
-      - id: USER-SERVICE
-        uri: lb://USER-SERVICE
+      - id: user-service
+        uri: lb://user-service
         predicates:
         - name: Path
           args:
@@ -29,8 +31,8 @@ spring:
           args:
             regexp: "/user/(?<remaining>.*)"
             replacement: "/${remaining}"
-      - id: RECOMMENDATION-SERVICE
-        uri: lb://RECOMMENDATION-SERVICE
+      - id: recommendation-service
+        uri: lb://recommendation-service
         predicates:
         - name: Path
           args:
@@ -49,6 +51,9 @@ management:
 ---
 spring:
   profiles: development
+  cloud:
+    kubernetes:
+      enabled: false
 eureka:
   instance:
     prefer-ip-address: true
@@ -68,6 +73,30 @@ eureka:
     fetchRegistry: true
     serviceUrl:
       defaultZone: http://discovery-service:8761/eureka/
+---
+spring:
+  profiles: kubernetes
+  cloud:
+    kubernetes:
+      enabled: true
+      discovery:
+        enabled: true
+      ribbon:
+        enabled: true
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+          url-expression: "'http://'+serviceId"
+kubernetes.trust.certificates: true
+management.endpoints.web.exposure.include: gateway,health
+# disable eureka
+ribbon.eureka.enabled: false
+eureka.client.enabled: false
+# kubernetes ribbon client requires a portName for each service
+#friend-service.ribbon.portName: http
+#user-service.ribbon.portName: http
+#recommendation-service.ribbon.portName: http
 ---
 spring:
   profiles: test

--- a/friend-service/pom.xml
+++ b/friend-service/pom.xml
@@ -76,6 +76,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-kubernetes-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
             <exclusions>
                 <exclusion>

--- a/friend-service/src/main/java/io/example/DataSourceConfiguration.java
+++ b/friend-service/src/main/java/io/example/DataSourceConfiguration.java
@@ -27,7 +27,7 @@ import javax.sql.DataSource;
  */
 @Configuration
 @EnableR2dbcRepositories
-@Profile({"development", "docker"})
+@Profile({"development", "docker", "kubernetes"})
 public class DataSourceConfiguration extends AbstractR2dbcConfiguration {
 
     @Value("${postgres.host}")

--- a/friend-service/src/main/resources/application.yml
+++ b/friend-service/src/main/resources/application.yml
@@ -66,6 +66,34 @@ eureka:
     serviceUrl:
       defaultZone: http://discovery-service:8761/eureka/
 ---
+postgres.port: 5432
+postgres.host: friend-db
+postgres.url: jdbc:postgresql://${postgres.host:localhost}:${postgres.port}/
+postgres.database-name: postgres
+postgres.password: example
+postgres.username: postgres
+spring:
+  profiles: kubernetes
+  cloud:
+    stream:
+      kafka:
+        binder:
+          brokers: kafka
+          defaultBrokerPort: 29092
+          zkNodes: zookeeper
+          defaultZkPort: 32181
+  datasource:
+    url: ${postgres.url}
+    data-username: ${postgres.username}
+    data-password: ${postgres.password}
+    driver-class-name: org.postgresql.Driver
+  liquibase:
+    url: ${postgres.url}
+    user: ${postgres.username}
+    password: ${postgres.password}
+ribbon.eureka.enabled: false
+eureka.client.enabled: false
+---
 spring:
   profiles: test
 eureka:

--- a/recommendation-service/src/main/resources/application.yml
+++ b/recommendation-service/src/main/resources/application.yml
@@ -62,4 +62,17 @@ eureka:
       defaultZone: http://discovery-service:8761/eureka/
 ---
 spring:
+  profiles: kubernetes
+  data:
+    neo4j:
+      uri: "bolt://neo4j:7687"
+  cloud:
+    stream:
+      kafka:
+        binder:
+          brokers: "kafka:29092"
+ribbon.eureka.enabled: false
+eureka.client.enabled: false
+---
+spring:
   profiles: test

--- a/user-service/src/main/java/io/example/DataSourceConfiguration.java
+++ b/user-service/src/main/java/io/example/DataSourceConfiguration.java
@@ -27,7 +27,7 @@ import javax.sql.DataSource;
  */
 @Configuration
 @EnableR2dbcRepositories
-@Profile({"docker", "development"})
+@Profile({"kubernetes", "docker", "development"})
 public class DataSourceConfiguration extends AbstractR2dbcConfiguration {
 
     @Value("${postgres.host}")

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -66,6 +66,34 @@ eureka:
     serviceUrl:
       defaultZone: http://discovery-service:8761/eureka/
 ---
+postgres.port: 5432
+postgres.host: user-db
+postgres.url: jdbc:postgresql://${postgres.host:localhost}:${postgres.port}/
+postgres.database-name: postgres
+postgres.username: postgres
+postgres.password: example
+spring:
+  profiles: kubernetes
+  cloud:
+    stream:
+      kafka:
+        binder:
+          brokers: kafka
+          defaultBrokerPort: 29092
+          zkNodes: zookeeper
+          defaultZkPort: 32181
+  datasource:
+    url: ${postgres.url}
+    data-username: ${postgres.username}
+    data-password: ${postgres.password}
+    driver-class-name: org.postgresql.Driver
+  liquibase:
+    url: ${postgres.url}
+    user: ${postgres.username}
+    password: ${postgres.password}
+ribbon.eureka.enabled: false
+eureka.client.enabled: false
+---
 spring:
   profiles: test
 eureka:


### PR DESCRIPTION
This brings in the spring cloud kubernetes dependencies and sets
up a new kubernetes profile for each application that can be used
to allow for kube discovery and ribbon.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>